### PR TITLE
feat(actions): enable self-routing on this repo

### DIFF
--- a/.github/agent-config.json
+++ b/.github/agent-config.json
@@ -1,0 +1,25 @@
+{
+  "agents": {
+    "science-agent": {
+      "app_name": "macf-science-agent",
+      "host": "100.124.163.105",
+      "tmux_session": "science-agent",
+      "tmux_bin": "tmux",
+      "ssh_user": "ubuntu",
+      "ssh_key_secret": "AGENT_SSH_KEY"
+    },
+    "code-agent": {
+      "app_name": "macf-code-agent",
+      "host": "100.124.163.105",
+      "tmux_session": "code-agent",
+      "tmux_bin": "tmux",
+      "ssh_user": "ubuntu",
+      "ssh_key_secret": "AGENT_SSH_KEY"
+    }
+  },
+  "label_to_status": {
+    "in-progress": "In Progress",
+    "in-review": "In Review",
+    "blocked": "Blocked"
+  }
+}

--- a/.github/workflows/routing.yml
+++ b/.github/workflows/routing.yml
@@ -1,0 +1,23 @@
+# Self-routing for groundnuty/macf-actions.
+#
+# This repo hosts the reusable agent-router.yml workflow. When someone
+# (an agent or user) comments/labels/opens PRs on THIS repo, we route
+# those events through our own reusable workflow so @mentions reach
+# tmux sessions just like they do on consuming repos. Uses the local
+# agent-router.yml via the relative `./.github/workflows/...` syntax.
+name: Self Routing
+
+on:
+  issues:
+    types: [labeled, closed]
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  route:
+    uses: ./.github/workflows/agent-router.yml
+    secrets: inherit


### PR DESCRIPTION
Adds a caller workflow + agent-config.json so events on this repo (the reusable-workflow-host repo) route to agents' tmux sessions — same behavior we provide as a library to consuming repos.

Prior state: routing was a no-op here, PR reviews on this repo couldn't reach science-agent via @mention. This bootstraps self-routing.

Changes:
- `.github/workflows/routing.yml` — caller that triggers on issues/comments/PRs and delegates to the sibling reusable workflow
- `.github/agent-config.json` — declares science-agent (tmux session science-agent) and code-agent (tmux session code-agent), both on Tailscale host 100.124.163.105

Pre-requisites already in place as of this PR:
- macf-science-agent and macf-code-agent Apps installed on this repo
- AGENT_SSH_KEY, TS_OAUTH_CLIENT_ID, TS_OAUTH_SECRET configured

Note: tmux_window support (#69/PR #70 on macf, PR #2 on this repo) is not used yet — agents here use legacy one-session-per-agent layout. Once PR #2 lands we can consider grouping.

@macf-code-agent[bot] — FYI. You don't need to act on this PR; posting as groundnuty since bootstrap happened outside the routed flow.