### PR TITLE
feat(routing): notify pr author on ci completion (check_suite)

### DIFF
--- a/.github/workflows/agent-router.yml
+++ b/.github/workflows/agent-router.yml
@@ -22,6 +22,10 @@ permissions:
   contents: read
   issues: write
   pull-requests: read
+  # checks: read needed by route-by-ci-completion (#6) to enumerate
+  # check_runs in the completed suite so the notification can name the
+  # first failing check (not just "CI failed").
+  checks: read
 
 jobs:
 
@@ -267,6 +271,178 @@ jobs:
               else
                 echo "Agent ${AGENT_NAME} is offline, skipping"
               fi
+            fi
+          done
+
+  # ─── CI COMPLETION ROUTING ───
+  #
+  # When a check_suite completes on a PR authored by one of our registered
+  # agents, notify the agent in its tmux session so it can merge (on
+  # success) or investigate (on failure) without polling. See #6.
+  #
+  # Fires once per check_suite.completed event. A repo with multiple CI
+  # workflows may produce multiple completed suites per commit (one per
+  # app). We accept this minor duplication rather than try to aggregate —
+  # the alternative is a timer-based cross-suite coalescer which is
+  # substantially more complex and adds latency.
+  route-by-ci-completion:
+    needs: config
+    if: >
+      (github.event_name == 'check_suite') &&
+      (github.event.action == 'completed')
+    runs-on: ubuntu-latest
+    env:
+      AGENT_SSH_KEY: ${{ secrets.AGENT_SSH_KEY }}
+      AGENTS: ${{ needs.config.outputs.agents }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CHECK_SUITE_ID: ${{ github.event.check_suite.id }}
+      CHECK_SUITE_HEAD_SHA: ${{ github.event.check_suite.head_sha }}
+      CHECK_SUITE_CONCLUSION: ${{ github.event.check_suite.conclusion }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci-runner
+
+      - name: Wait for Tailscale network
+        run: sleep 10
+
+      - name: Route CI completion to agent-authored PRs
+        run: |
+          set -euo pipefail
+
+          # Only act on terminal conclusions. Skip neutral/cancelled/
+          # skipped — rarely need agent action and would add noise.
+          case "$CHECK_SUITE_CONCLUSION" in
+            success|failure|timed_out|action_required)
+              ;;
+            *)
+              echo "Conclusion '$CHECK_SUITE_CONCLUSION' is not actionable, skipping"
+              exit 0
+              ;;
+          esac
+
+          # Enumerate PRs associated with this check_suite. The
+          # check_suite event payload has `pull_requests[]` with basic
+          # info but not `draft` / `state`, so we query the PR directly.
+          PR_NUMBERS=$(gh api \
+            "/repos/${REPO}/commits/${CHECK_SUITE_HEAD_SHA}/pulls" \
+            --jq '.[] | .number')
+
+          if [ -z "$PR_NUMBERS" ]; then
+            echo "No PR associated with SHA ${CHECK_SUITE_HEAD_SHA}, skipping"
+            exit 0
+          fi
+
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          echo "$AGENT_SSH_KEY" > ~/.ssh/id_agent
+          chmod 600 ~/.ssh/id_agent
+
+          for PR_NUMBER in $PR_NUMBERS; do
+            PR_JSON=$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}")
+            PR_STATE=$(echo "$PR_JSON" | jq -r '.state')
+            PR_DRAFT=$(echo "$PR_JSON" | jq -r '.draft')
+            PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.user.login')
+            PR_HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+            PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+
+            # Staleness guard: a force-push during CI produces a
+            # workflow_run/check_suite on the OLD head_sha. If that
+            # completes after a new one starts, the notification would
+            # be misleading — skip it.
+            if [ "$PR_HEAD_SHA" != "$CHECK_SUITE_HEAD_SHA" ]; then
+              echo "PR #${PR_NUMBER} HEAD moved past ${CHECK_SUITE_HEAD_SHA} (now ${PR_HEAD_SHA}), skipping"
+              continue
+            fi
+
+            if [ "$PR_STATE" != "open" ]; then
+              echo "PR #${PR_NUMBER} state=${PR_STATE}, skipping"
+              continue
+            fi
+
+            if [ "$PR_DRAFT" = "true" ]; then
+              echo "PR #${PR_NUMBER} is a draft, skipping"
+              continue
+            fi
+
+            # Author-to-agent lookup: PR's author.login must match one
+            # of the configured agent app_names (suffix `[bot]`).
+            AGENT_NAME=""
+            for CANDIDATE in $(echo "$AGENTS" | jq -r 'keys[]'); do
+              APP_NAME=$(echo "$AGENTS" | jq -r --arg a "$CANDIDATE" '.[$a].app_name // empty')
+              if [ "$PR_AUTHOR" = "${APP_NAME}[bot]" ]; then
+                AGENT_NAME="$CANDIDATE"
+                break
+              fi
+            done
+
+            if [ -z "$AGENT_NAME" ]; then
+              echo "PR #${PR_NUMBER} author '${PR_AUTHOR}' is not a registered agent, skipping"
+              continue
+            fi
+
+            # Build the notification prompt.
+            PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
+            if [ "$CHECK_SUITE_CONCLUSION" = "success" ]; then
+              PROMPT="PR #${PR_NUMBER} (\"${PR_TITLE}\"): CI SUCCESS. ${PR_URL}. Next: merge if you're the author."
+            else
+              # On failure, name the first failing check for faster
+              # triage. `gh api` returns check_runs for this suite;
+              # filter to failed ones.
+              FAILING=$(gh api \
+                "/repos/${REPO}/check-suites/${CHECK_SUITE_ID}/check-runs" \
+                --jq '.check_runs[] | select(.conclusion=="failure" or .conclusion=="timed_out" or .conclusion=="action_required") | .name' \
+                | head -1)
+              if [ -n "$FAILING" ]; then
+                PROMPT="PR #${PR_NUMBER} (\"${PR_TITLE}\"): CI FAILED. First failing check: '${FAILING}'. ${PR_URL}. Next: investigate + push fix."
+              else
+                PROMPT="PR #${PR_NUMBER} (\"${PR_TITLE}\"): CI FAILED (${CHECK_SUITE_CONCLUSION}). ${PR_URL}. Next: investigate + push fix."
+              fi
+            fi
+
+            HOST=$(echo "$AGENTS" | jq -r --arg a "$AGENT_NAME" '.[$a].host')
+            SESSION=$(echo "$AGENTS" | jq -r --arg a "$AGENT_NAME" '.[$a].tmux_session')
+            WINDOW=$(echo "$AGENTS" | jq -r --arg a "$AGENT_NAME" '.[$a].tmux_window // empty')
+            SSH_USER=$(echo "$AGENTS" | jq -r --arg a "$AGENT_NAME" '.[$a].ssh_user')
+            TMUX_BIN=$(echo "$AGENTS" | jq -r --arg a "$AGENT_NAME" '.[$a].tmux_bin // "tmux"')
+            WORKSPACE_DIR=$(echo "$AGENTS" | jq -r --arg a "$AGENT_NAME" '.[$a].workspace_dir // empty')
+
+            if [ -n "$WINDOW" ]; then
+              TARGET="${SESSION}:${WINDOW}"
+            else
+              TARGET="$SESSION"
+            fi
+
+            # Shell-quoting caveat: PR_TITLE is user-controlled (the
+            # PR-authoring bot chose it). The helper path uses single-
+            # quoted args; a title containing `'` would break remote
+            # parse. Strip single quotes defensively before passing.
+            SAFE_PROMPT=$(echo "$PROMPT" | tr -d "'")
+
+            HELPER="${WORKSPACE_DIR}/.claude/scripts/tmux-send-to-claude.sh"
+            if [ -n "$WORKSPACE_DIR" ] && ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=accept-new \
+              -i ~/.ssh/id_agent "${SSH_USER}@${HOST}" \
+              "${TMUX_BIN} has-session -t ${SESSION} 2>/dev/null && test -x '${HELPER}'" 2>/dev/null; then
+              if ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=accept-new \
+                -i ~/.ssh/id_agent "${SSH_USER}@${HOST}" \
+                "'${HELPER}' '${TARGET}' '${SAFE_PROMPT}'"; then
+                echo "Routed CI completion for PR #${PR_NUMBER} to ${AGENT_NAME} via helper (target=${TARGET})"
+              else
+                echo "Agent ${AGENT_NAME} helper invocation failed for PR #${PR_NUMBER}"
+              fi
+            elif ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=accept-new \
+              -i ~/.ssh/id_agent "${SSH_USER}@${HOST}" \
+              "${TMUX_BIN} has-session -t ${SESSION} 2>/dev/null \
+                && ${TMUX_BIN} send-keys -t ${TARGET} C-u \
+                && ${TMUX_BIN} send-keys -t ${TARGET} '${SAFE_PROMPT}' Enter \
+                && sleep 1 \
+                && ${TMUX_BIN} send-keys -t ${TARGET} Enter"; then
+              echo "Routed CI completion for PR #${PR_NUMBER} to ${AGENT_NAME} via inline (target=${TARGET})"
+            else
+              echo "Agent ${AGENT_NAME} is offline, skipping CI-completion notification for PR #${PR_NUMBER}"
             fi
           done
 

--- a/.github/workflows/routing.yml
+++ b/.github/workflows/routing.yml
@@ -28,6 +28,11 @@ permissions:
   contents: read
   issues: write
   pull-requests: read
+  # `checks: read` is required for route-by-ci-completion (#6) to
+  # enumerate check_runs in a completed suite. Callers of this reusable
+  # workflow who subscribe to `check_suite` MUST grant this or the
+  # failing-check name lookup will 403. See CHANGELOG 1.1.0.
+  checks: read
 
 jobs:
   route:

--- a/.github/workflows/routing.yml
+++ b/.github/workflows/routing.yml
@@ -14,6 +14,11 @@ on:
     types: [opened]
   pull_request_review:
     types: [submitted]
+  # CI-completion routing (#6). Fires the route-by-ci-completion job
+  # in the reusable workflow to notify agent-authored PRs when CI
+  # finishes, eliminating the wait-for-human-ping polling pattern.
+  check_suite:
+    types: [completed]
 
 # Caller must grant at least what the reusable workflow expects
 # (see groundnuty/macf-actions/.github/workflows/agent-router.yml's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] — 2026-04-17
+## [1.3.0] — 2026-04-17
 
 ### Added
 
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Non-breaking caller change
 
-Consumers subscribing to the reusable workflow need to add `check_suite: { types: [completed] }` to their caller workflow's `on:` list to receive CI-completion routing. Without this, existing v1.0 behavior (label + mention routing) continues unchanged — the new job simply never fires.
+Consumers subscribing to the reusable workflow need to add `check_suite: { types: [completed] }` to their caller workflow's `on:` list to receive CI-completion routing. Without this, existing v1.2 behavior (label + mention routing) continues unchanged — the new job simply never fires.
 
 ### Permissions — ⚠ consumer action required
 
@@ -24,7 +24,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: read
-  checks: read    # add for CI-completion routing (v1.1+)
+  checks: read    # add for CI-completion routing (v1.3+)
 ```
 
 Known consumers to update (as of this release): `groundnuty/macf`, `groundnuty/academic-resume`. Without `checks: read`, existing label/mention routing continues to work; only the CI-completion routing job is affected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,19 @@ All notable changes to this project will be documented in this file. The format 
 
 Consumers subscribing to the reusable workflow need to add `check_suite: { types: [completed] }` to their caller workflow's `on:` list to receive CI-completion routing. Without this, existing v1.0 behavior (label + mention routing) continues unchanged — the new job simply never fires.
 
-### Permissions
+### Permissions — ⚠ consumer action required
 
-The reusable workflow now requests `checks: read` to enumerate `check_runs` in a completed suite. Consumers inheriting permissions via `secrets: inherit` get this automatically on the managed runner; no caller-side change needed.
+The reusable workflow now requests `checks: read` to enumerate `check_runs` in a completed suite. GitHub's `workflow_call` rule is that a reusable workflow's `GITHUB_TOKEN` cannot exceed the caller's permissions — so **every consumer that subscribes to `check_suite` must also grant `checks: read` in its caller workflow's `permissions:` block**, or the failing-check lookup will 403. Existing consumers upgrading to `@v1` (floating tag) should update their `routing.yml` to match:
+
+```yaml
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+  checks: read    # add for CI-completion routing (v1.1+)
+```
+
+Known consumers to update (as of this release): `groundnuty/macf`, `groundnuty/academic-resume`. Without `checks: read`, existing label/mention routing continues to work; only the CI-completion routing job is affected.
 
 ## [1.0.0] — 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] — 2026-04-17
+
+### Added
+
+- `route-by-ci-completion` job in `agent-router.yml` (#6). Notifies the authoring agent's tmux session when CI finishes on an agent-authored PR, eliminating the wait-for-human-ping polling pattern. Filters out human/external authors, draft PRs, stale CI after force-push, and non-actionable conclusions (`neutral`/`cancelled`/`skipped`).
+- On success: routes a prompt like `PR #N: CI SUCCESS. URL. Next: merge if you're the author.`
+- On failure: names the first failing check (from `check_runs` enumeration) for faster triage.
+- Shell-quoting hardened: strips single quotes from generated prompts (user-controlled PR titles) to prevent remote-parse breakage.
+
+### Non-breaking caller change
+
+Consumers subscribing to the reusable workflow need to add `check_suite: { types: [completed] }` to their caller workflow's `on:` list to receive CI-completion routing. Without this, existing v1.0 behavior (label + mention routing) continues unchanged — the new job simply never fires.
+
+### Permissions
+
+The reusable workflow now requests `checks: read` to enumerate `check_runs` in a completed suite. Consumers inheriting permissions via `secrets: inherit` get this automatically on the managed runner; no caller-side change needed.
+
 ## [1.0.0] — 2026-04-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ on:
   issue_comment: { types: [created] }
   pull_request: { types: [opened] }
   pull_request_review: { types: [submitted] }
-  check_suite: { types: [completed] }   # CI-completion routing (v1.1+)
+  check_suite: { types: [completed] }   # CI-completion routing (v1.3+)
 permissions:
   contents: read
   issues: write
@@ -29,7 +29,7 @@ jobs:
     secrets: inherit
 ```
 
-**Upgrading from v1.0 → v1.1:** if your caller workflow already defines a `permissions:` block, add `checks: read`. Without it the CI-completion routing job will 403 when it tries to enumerate `check_runs` to name the first failing check. GitHub's `workflow_call` rule is that the reusable workflow's token can't exceed the caller's scope, so this permission must be granted at the caller level.
+**Upgrading to v1.3 (or via the floating `@v1` tag once it moves past v1.3.0):** if your caller workflow already defines a `permissions:` block, add `checks: read`. Without it the CI-completion routing job will 403 when it tries to enumerate `check_runs` to name the first failing check. GitHub's `workflow_call` rule is that the reusable workflow's token can't exceed the caller's scope, so this permission must be granted at the caller level.
 
 That's it. GitHub downloads the workflow definition at run time and passes your secrets and events to it.
 
@@ -103,7 +103,7 @@ The workflow provides four jobs:
 
 1. **`route-by-label`** — when an issue is labeled with an agent name, route it to that agent via SSH + tmux send-keys
 2. **`route-by-mention`** — when an agent is `@mentioned` in a comment, PR body, or review, route the mention to the agent
-3. **`route-by-ci-completion`** (v1.1+) — when CI finishes on an agent-authored PR, notify the authoring agent in its tmux session so it can merge on success or push a fix on failure without polling. Filters:
+3. **`route-by-ci-completion`** (v1.3+) — when CI finishes on an agent-authored PR, notify the authoring agent in its tmux session so it can merge on success or push a fix on failure without polling. Filters:
     - Only fires for PRs authored by agents configured in `agent-config.json` (skips human / dependabot / external authors)
     - Skips draft PRs
     - Skips stale CI (when the PR HEAD moved past the SHA the suite ran on, e.g. after a force-push)

--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@ on:
   pull_request: { types: [opened] }
   pull_request_review: { types: [submitted] }
   check_suite: { types: [completed] }   # CI-completion routing (v1.1+)
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+  checks: read                          # required by CI-completion routing
 jobs:
   route:
     uses: groundnuty/macf-actions/.github/workflows/agent-router.yml@v1
     secrets: inherit
 ```
+
+**Upgrading from v1.0 → v1.1:** if your caller workflow already defines a `permissions:` block, add `checks: read`. Without it the CI-completion routing job will 403 when it tries to enumerate `check_runs` to name the first failing check. GitHub's `workflow_call` rule is that the reusable workflow's token can't exceed the caller's scope, so this permission must be granted at the caller level.
 
 That's it. GitHub downloads the workflow definition at run time and passes your secrets and events to it.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ on:
   issue_comment: { types: [created] }
   pull_request: { types: [opened] }
   pull_request_review: { types: [submitted] }
+  check_suite: { types: [completed] }   # CI-completion routing (v1.1+)
 jobs:
   route:
     uses: groundnuty/macf-actions/.github/workflows/agent-router.yml@v1
@@ -91,11 +92,16 @@ Check [CHANGELOG.md](./CHANGELOG.md) for breaking changes between majors.
 
 ## Behavior
 
-The workflow provides three jobs:
+The workflow provides four jobs:
 
 1. **`route-by-label`** — when an issue is labeled with an agent name, route it to that agent via SSH + tmux send-keys
 2. **`route-by-mention`** — when an agent is `@mentioned` in a comment, PR body, or review, route the mention to the agent
-3. **`cleanup-labels`** — when an issue closes, remove status labels (`in-progress`, `in-review`, `blocked`)
+3. **`route-by-ci-completion`** (v1.1+) — when CI finishes on an agent-authored PR, notify the authoring agent in its tmux session so it can merge on success or push a fix on failure without polling. Filters:
+    - Only fires for PRs authored by agents configured in `agent-config.json` (skips human / dependabot / external authors)
+    - Skips draft PRs
+    - Skips stale CI (when the PR HEAD moved past the SHA the suite ran on, e.g. after a force-push)
+    - Only terminal conclusions (`success`, `failure`, `timed_out`, `action_required`); skips `neutral`, `cancelled`, `skipped`
+4. **`cleanup-labels`** — when an issue closes, remove status labels (`in-progress`, `in-review`, `blocked`)
 
 If an agent is unreachable, the workflow adds the `agent-offline` label so the agent can pick up missed work on startup.
 


### PR DESCRIPTION
## Summary

Adds a new `route-by-ci-completion` job in the reusable agent-router workflow. Triggers on `check_suite.completed` and routes a tmux prompt to the authoring agent when CI finishes on an agent-authored PR — eliminates the "post ready-for-review then sit idle waiting for @mention" pattern.

## Changes

### `agent-router.yml`
- New job `route-by-ci-completion` (after `route-by-mention`, before `cleanup-labels`)
- Filters: terminal-conclusion only, agent-authored PRs only, non-draft, non-stale (head_sha matches), open state
- Failing-check name pulled from `/check-suites/:id/check-runs` for faster triage
- Adds `checks: read` permission (needed for check_runs enumeration)
- Shell-quoting hardening: strip single quotes from PR title before ssh-passthrough

### `routing.yml` (self-test caller)
- Subscribes to `check_suite: { types: [completed] }` so the new job fires on this repo's own PRs

### `README.md`
- Documents the new job and its filters
- Usage example includes the new event subscription

### `CHANGELOG.md`
- `1.1.0` entry describing the additive change and the non-breaking caller-side subscription update

## Filter chain

Before dispatching, skip if any of:
1. Conclusion is not actionable (`neutral`/`cancelled`/`skipped`)
2. No PR associated with the suite's head_sha
3. `pr.head.sha` ≠ `check_suite.head_sha` (force-push staleness)
4. `pr.state` ≠ `open`
5. `pr.draft` = `true`
6. `pr.user.login` is not one of the configured agent `app_name`s

## Message shapes

**Success:**
```
PR #N ("title"): CI SUCCESS. <url>. Next: merge if you're the author.
```

**Failure:**
```
PR #N ("title"): CI FAILED. First failing check: '<name>'. <url>. Next: investigate + push fix.
```

## Test plan

- [ ] **Manual:** open a PR as `macf-code-agent[bot]`, let CI fail (e.g. bad commitlint subject), verify code-agent's tmux receives the failure notification within ~30s of CI completion
- [ ] **Manual:** push the fix, verify success notification arrives
- [ ] **Manual:** open a human-authored PR on the same repo, verify no notification routes (agent-author filter)
- [ ] **Manual:** force-push to an in-flight PR, verify the old suite's notification is skipped as stale
- [ ] **Manual:** open a draft PR with matching agent author, verify no notification (draft filter)
- [ ] **YAML parse:** files parse cleanly via lightweight syntactic check

## Out of scope

- Synthetic-payload shell tests for agent-author detection + SSH dispatch. macf-actions has no existing test infra and setting up a bash-based testing framework is scope-creep for this PR. Filing as a follow-up once the manual test plan validates behavior.
- Channel-transport (mTLS POST instead of SSH+tmux). Captured in the pre-existing v2 plan — this job migrates alongside the other routing jobs.

Refs #6