### PR TITLE
ci: add actionlint + commitlint (parity with macf repo, #15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+# Parity with groundnuty/macf's ci.yml (#15). The main product of this
+# repo is a reusable workflow consumed by downstream repos — any YAML
+# syntax or logic drift leaks to all callers on their next run. This
+# job catches regressions pre-merge.
+#
+# Two checks:
+#   - actionlint: validates workflow YAML (syntax, unused permissions,
+#     shell-injection-by-quotation, typos in contexts like ${{ ... }})
+#   - commitlint: enforces the same 13-type enum as groundnuty/macf so
+#     release-note derivation + `git log --grep='^security|^reliability'`
+#     work consistently across the two repos.
+#
+# Security note: all GitHub-context interpolations in run: scripts use
+# env: with quoted variable expansion rather than direct ${{ }} splicing.
+# Only `github.event.pull_request.{base,head}.sha` are used here — both
+# non-attacker-controllable — but the env-var pattern is best practice
+# for any future edits that add user-controllable inputs.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'commitlint.config.mjs'
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Run actionlint
+        # reviewdog/action-actionlint installs actionlint in-situ at a
+        # pinned tag. Non-critical tooling — a break here fails CI but
+        # cannot leak into the shipped reusable workflow.
+        uses: reviewdog/action-actionlint@v1
+        with:
+          fail_on_error: 'true'
+          reporter: github-pr-review
+
+  commitlint:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
+        with:
+          node-version: 22
+
+      - name: Install commitlint
+        run: npm install -g @commitlint/cli @commitlint/config-conventional
+
+      - name: Lint commits
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: npx commitlint --from "$BASE_SHA" --to "$HEAD_SHA"

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ If an agent is unreachable, the workflow adds the `agent-offline` label so the a
 
 The v1 workflow uses SSH + tmux for message delivery. v2 will swap this for mTLS HTTP POST to each agent's channel endpoint (see [macf P3](https://github.com/groundnuty/macf/blob/main/design/phases/P3-cert-management.md) for the cert infrastructure). Consumers opt in by bumping `@v1` → `@v2`.
 
+## Contributing
+
+CI enforces two checks on PRs:
+
+1. **[actionlint](https://github.com/rhysd/actionlint)** — validates `.github/workflows/*.yml` for syntax, unused permissions, shell-injection-by-quotation, and typos in `${{ ... }}` contexts. Runs on every push and PR that touches workflows.
+2. **[commitlint](https://github.com/conventional-changelog/commitlint)** — enforces the 13-type enum shared with [`groundnuty/macf`](https://github.com/groundnuty/macf/blob/main/commitlint.config.mjs): `feat / fix / security / reliability / refactor / perf / docs / test / chore / ci / revert / build / style`. Parity across the two repos means release-note derivation + `git log --grep='^security|^reliability'` work consistently.
+
+PR subjects follow [Conventional Commits](https://www.conventionalcommits.org/) format with one of those types. Subject capped at 100 chars (`@commitlint/config-conventional` default).
+
 ## See also
 
 - [MACF framework](https://github.com/groundnuty/macf) — agent implementation, CLI, plugin

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,32 @@
+// Commit type convention for macf-actions — mirrors groundnuty/macf's
+// 13-type enum for consistency. Release notes derivation + `git log
+// --grep='^security\|^reliability'` are most useful when commit
+// subjects follow the same vocabulary across the two repos.
+//
+// See groundnuty/macf#15 for the parity rationale.
+//
+//   feat         — new consumer-visible feature (new routing event,
+//                  new v-tag entry point, etc.)
+//   fix          — bug fix (no security implication)
+//   security     — security fix (vulnerability, hardening)
+//   reliability  — observability / robustness hardening
+//   refactor     — behavior-preserving restructure
+//   perf         — performance improvement
+//   docs         — documentation only
+//   test         — tests only
+//   chore        — tooling, build, meta (non-consumer-facing)
+//   ci           — CI changes (this repo's own CI, not the shipped workflow)
+//   build        — build system changes
+//   style        — formatting only
+//   revert       — revert a prior commit
+
+export default {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [2, 'always', [
+      'feat', 'fix', 'security', 'reliability',
+      'refactor', 'perf', 'docs', 'test',
+      'chore', 'ci', 'revert', 'build', 'style',
+    ]],
+  },
+};


### PR DESCRIPTION
## Summary

Parity with `groundnuty/macf`'s CI gate. Adds two automated checks that were missing on this repo despite it being the source of truth for downstream consumers' routing workflow.

### Changes

- **`.github/workflows/ci.yml`** — actionlint on push + PR (validates workflow YAML syntax, permissions, shell-injection surface, context typos); commitlint on PR only (enforces the shared 13-type enum).
- **`commitlint.config.mjs`** — mirrors `groundnuty/macf`'s type-enum exactly: `feat / fix / security / reliability / refactor / perf / docs / test / chore / ci / revert / build / style`. Release-note derivation + `git log --grep='^security|^reliability'` stay consistent across both repos.
- **`README.md` Contributing section** — documents the two checks + links to macf's commitlint config as the source of truth for the type-enum.

### Security hygiene

All `github.event.*` interpolations in `run:` scripts go through `env:` variable quoting. Current usage is `pull_request.base.sha` / `pull_request.head.sha` (non-attacker-controllable), but the pattern is in place for any future edits that add user-controllable fields.

### Actions pinning

`actions/checkout@v4.2.2` SHA and `actions/setup-node@v5.0.0` SHA — matching the repo's existing pinning pattern in `agent-router.yml`. `reviewdog/action-actionlint@v1` tag-pinned (non-critical tooling; a break there only fails CI — cannot leak into the shipped workflow).

## Test plan

- [ ] CI runs actionlint against its own PR → should succeed (existing workflows should be clean; if any issues surface they're in scope to fix here)
- [ ] CI runs commitlint against this PR's subject (`ci: add actionlint + commitlint (parity with macf repo, #15)`) → passes
- [ ] Once merged, future workflow edits + commit subjects get validated pre-merge

Closes #15.